### PR TITLE
Stops Mootools (and presumably other prototype based stuff) from messing up internal arrays

### DIFF
--- a/jquery.multiselect.js
+++ b/jquery.multiselect.js
@@ -392,6 +392,12 @@
                     container.append('<ul></ul>');
 
                     for( var gKey in thisOption.options ) {
+                        // Prevent prototype methods injected into options from
+                        // being iterated over.
+                        if (!thisOption.options.hasOwnProperty(gKey)) {
+                          continue;
+                        }
+
                         var thisGOption = thisOption.options[ gKey ];
                         var gContainer  = $('<li></li>').addClass('ms-reflow');
 

--- a/jquery.multiselect.js
+++ b/jquery.multiselect.js
@@ -368,6 +368,12 @@
             }
 
             for( var key in options ) {
+                // Prevent prototype methods injected into options from being
+                // iterated over.
+                if (!options.hasOwnProperty(key)) {
+                  continue;
+                }
+
                 var thisOption = options[ key ];
                 var container  = $('<li></li>');
 
@@ -382,7 +388,7 @@
                     if( instance.options.selectGroup ) {
                         container.append('<a href="#" class="ms-selectall">Select all</a>')
                     }
-                    
+
                     container.append('<ul></ul>');
 
                     for( var gKey in thisOption.options ) {


### PR DESCRIPTION
Seems to resolve issue #8. Makes sure that injected prototype methods don't get iterated over when populating the multiselect control. 