### PR TITLE
[bug] changed property names of float to avoid build crash

### DIFF
--- a/jquery.multiselect.js
+++ b/jquery.multiselect.js
@@ -315,7 +315,7 @@
             if( hasOptGroup ) {
                 // float non grouped options
                 optionsList.find('> li:not(.optgroup)').css({
-                    float: 'left',
+                    'float': 'left',
                     width: (100 / instance.options.columns) +'%'
                 });
 
@@ -334,7 +334,7 @@
                 // for crappy IE versions float grouped options
                 if( this._ieVersion() && (this._ieVersion() < 10) ) {
                     optionsList.find('li.optgroup > ul > li').css({
-                        float: 'left',
+                        'float': 'left',
                         width: (100 / instance.options.columns) +'%'
                     });
                 }
@@ -353,7 +353,7 @@
                 // for crappy IE versions float grouped options
                 if( this._ieVersion() && (this._ieVersion() < 10) ) {
                     optionsList.find('> li').css({
-                        float: 'left',
+                        'float': 'left',
                         width: (100 / instance.options.columns) +'%'
                     });
                 }


### PR DESCRIPTION
We encountered during a release of a project that the property id naming float crashes yui compressor builds at version 2.4.7. Please consider merging this fix to avoid such crashes. Thank u.

( Reason is usage of a reserved word. http://www.w3schools.com/js/js_reserved.asp )