### PR TITLE
new option for placeholder control

### DIFF
--- a/jquery.multiselect.css
+++ b/jquery.multiselect.css
@@ -16,6 +16,9 @@
     color: #aaa;
     outline-offset: -2px;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .ms-options-wrap > button > span {

--- a/jquery.multiselect.js
+++ b/jquery.multiselect.js
@@ -54,16 +54,17 @@
         },
 
         // general options
-        selectAll          : false, // add select all option
-        selectGroup        : false, // select entire optgroup
-        minHeight          : 200,   // minimum height of option overlay
-        maxHeight          : null,  // maximum height of option overlay
-        maxWidth           : null,  // maximum width of option overlay (or selector)
-        maxPlaceholderWidth: null,  // maximum width of placeholder button
-        maxPlaceholderOpts : 10,    // maximum number of placeholder options to show until "# selected" shown instead
-        showCheckbox       : true,  // display the checkbox to the user
-        checkboxAutoFit    : false,  // auto calc checkbox padding
-        optionAttributes   : [],    // attributes to copy to the checkbox from the option element
+        selectAll              : false, // add select all option
+        selectGroup            : false, // select entire optgroup
+        minHeight              : 200,   // minimum height of option overlay
+        maxHeight              : null,  // maximum height of option overlay
+        maxWidth               : null,  // maximum width of option overlay (or selector)
+        maxPlaceholderWidth    : null,  // maximum width of placeholder button
+        maxPlaceholderOpts     : 10,    // maximum number of placeholder options to show until "# selected" shown instead
+        showCheckbox           : true,  // display the checkbox to the user
+        checkboxAutoFit        : false,  // auto calc checkbox padding
+        optionAttributes       : [],    // attributes to copy to the checkbox from the option element
+        replacePlaceholderText : true, // replace text of placeholder if button is too small
 
         // Callbacks
         onLoad        : function( element ){},           // fires at end of list initialization
@@ -838,7 +839,7 @@
                 placeholderTxt.text( instance.options.texts.placeholder );
             }
             // if copy is larger than button width use "# selected"
-            else if( (placeholderTxt.width() > placeholder.width()) || (selOpts.length != selectVals.length) ) {
+            else if( instance.options.replacePlaceholderText && ((placeholderTxt.width() > placeholder.width()) || (selOpts.length != selectVals.length)) ) {
                 placeholderTxt.text( selectVals.length + instance.options.texts.selectedOptions );
             }
         },


### PR DESCRIPTION
I've added new option to settings that control should app update placeholder text or no when button is to small for selected options. It defaults to true. Name of option `replacePlaceholderText`. also I've added `    text-overflow: ellipsis;` to the style of placeholder.