### PR TITLE
Update documentation for selectedOptions parameter with template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $('select[multiple]').multiselect( 'loadOptions', [{
 | - placeholder          | string   | Select options | default text for dropdown      |
 | - search               | string   | Search         | search input placeholder text  |
 | - searchNoResult       | string   | No results     | search results not found text  |
-| - selectedOptions      | string   |  selected      | selected suffix text           |
+| - selectedOptions      | string   |  selected      | text suffix for selected items, supports templating (e.g., #cnt# can be used as a placeholder for the count of selected items).           |
 | - selectAll            | string   | Select all     | select all text                |
 | - unselectAll          | string   | Unselect all   | unselect all text              |
 | - noneSelected         | string   | None Selected  | None selected text             |


### PR DESCRIPTION
Added detailed information about the selectedOptions parameter in the documentation, highlighting its ability to support templating (e.g., #cnt# as a placeholder for the count of selected items). This update ensures users are aware of the flexible text customization options available in the multiselect component.

Example usage:

javascript
Copy
$('.multiselect-element').multiselect({  
    texts: {  
        selectedOptions: 'Selected: #cnt#',  
    }  
});